### PR TITLE
Add tracing-subscriber env-filter feature

### DIFF
--- a/conductor-cli/Cargo.toml
+++ b/conductor-cli/Cargo.toml
@@ -27,7 +27,7 @@ futures-util = "0.3"
 thiserror = "1.0"
 tokio = { version = "1", features = ["full"] }
 tracing = "0.1.37"
-tracing-subscriber = { version = "0.3.16", features = ["fmt"] }
+tracing-subscriber = { version = "0.3.16", features = ["fmt", "env-filter"] }
 serde_json = "1.0"
 
 [dev-dependencies]


### PR DESCRIPTION
I needed to set this explicitly as discovered by running `cargo install --path conductor-cli`