### PR TITLE
add `shell` machine command

### DIFF
--- a/conductor-cli/src/opts.rs
+++ b/conductor-cli/src/opts.rs
@@ -117,6 +117,7 @@ pub enum Machine {
     Attach(Attach),
     Stats(Stats),
     Dump(Dump),
+    Shell(Shell),
 }
 
 /// List machines
@@ -156,6 +157,15 @@ pub struct Stats {
 pub struct Dump {
     #[command(flatten)]
     pub system: CommonSystemOptions,
+}
+
+/// Open a shell within the machine
+#[derive(Parser, Debug)]
+pub struct Shell {
+    #[command(flatten)]
+    pub system: CommonSystemOptions,
+
+    pub machine_name: MachineName,
 }
 
 #[derive(Parser, Debug)]

--- a/conductor/src/system/mod.rs
+++ b/conductor/src/system/mod.rs
@@ -97,6 +97,19 @@ impl System {
         bail!("machine not found")
     }
 
+    pub fn get_container_by_component_name(&self, component_name: &str) -> Result<&Container> {
+        let full_component_name = self.container_runtime_name_for_machine_named(component_name)?;
+        for container in &self.containers {
+            if let Some(container_name) = container.name() {
+                if container_name == full_component_name.as_str() {
+                    return Ok(container);
+                }
+            }
+        }
+
+        bail!("machine not found")
+    }
+
     pub async fn build_runtime_containers_from_deployment(&mut self) -> Result<()> {
         debug_assert!(self.containers.is_empty());
         let deployment = self.deployment()?;

--- a/test_resources/systems/colorful-output/color-test.sh
+++ b/test_resources/systems/colorful-output/color-test.sh
@@ -18,7 +18,7 @@ for i in {0..255} ; do
 
     # Check whether to print new line
     [ $(( ($i +  1) % 4 )) == 0 ] && set1=1 || set1=0
-    [ $(( ($i - 15) % 6 )) == 0 ] && set2=1 || set2=0
+    [ $(( ($i - 15) % 4 )) == 0 ] && set2=1 || set2=0
     if ( (( set1 == 1 )) && (( i <= 15 )) ) || ( (( set2 == 1 )) && (( i > 15 )) ); then
         printf "\e[0m\n";
     fi
@@ -28,7 +28,7 @@ done
 # RGB Color
 # From https://unix.stackexchange.com/a/404415
 
-awk -v term_cols="${width:-$(tput cols || echo 80)}" 'BEGIN{
+awk -v term_cols="${width:-80}" 'BEGIN{
     s="/\\";
     for (colnum = 0; colnum<term_cols; colnum++) {
         r = 255-(colnum*255/term_cols);


### PR DESCRIPTION
The user experience on this is crap at the moment because `bollard` won't let me have any access to stdout until it sees a newline char.

I want to get this in in it's slightly sorry state and go swap out the api library for `docker-api`, which I _think_ doesn't do that, before I go any further on this part.